### PR TITLE
Handle case: 'no response' from server

### DIFF
--- a/request.py
+++ b/request.py
@@ -3,20 +3,14 @@ import time
 import psycopg2
 
 def check_endpoint(url):
-    try:
-        response = requests.get(url, timeout=5)
-        response_time_ms = response.elapsed.total_seconds() * 1000
-        
-        conn = psycopg2.connect(
+    conn = psycopg2.connect(
             dbname="postgres",
             user="postgres",
             password="mysecretpassword",
             host="db",
             port="5432"
         )
-        
-        try:
-            with conn.cursor() as cursor:
+    with conn.cursor() as cursor:
                 cursor.execute("""
                     CREATE TABLE IF NOT EXISTS response_times (
                         id SERIAL PRIMARY KEY,
@@ -27,36 +21,19 @@ def check_endpoint(url):
                     );
                 """)
                 conn.commit()
-        
-            with conn.cursor() as cursor:
-                cursor.execute("""
-                    INSERT INTO response_times (url, response_code, response_time_ms, checked_at)
-                    VALUES (%s, %s, %s, NOW());
-                """, (url, response.status_code, response_time_ms))
-                conn.commit()
-
-        except Exception as e:
-            print(f"Database operation failed: {str(e)}")
-        finally:
-            conn.close()
-            
+    try:
+        response = requests.get(url, timeout=5).status_code
+        response_time_ms = response.elapsed.total_seconds() * 1000
     except requests.exceptions.RequestException as e:
-        print(f"Request to {url} failed. Error: {str(e)}")
-
-        conn = psycopg2.connect(
-            dbname="postgres",
-            user="postgres",
-            password="mysecretpassword",
-            host="db",
-            port="5432"
-        )
-
-        with conn.cursor() as cursor:
+       response = 500
+       response_time_ms = 0
+    with conn.cursor() as cursor:
                 cursor.execute("""
                     INSERT INTO response_times (url, response_code, response_time_ms, checked_at)
                     VALUES (%s, %s, %s, NOW());
-                """, (url, "0", 0))
+                """, (url, response, response_time_ms))
                 conn.commit()
+    conn.close()
 
 url_to_check = 'https://www.python.org'
 


### PR DESCRIPTION
so downtime can be correctly logged to the DB.

This simplifies to the try block to just the request method. Much easier to read the code now.